### PR TITLE
Documentación comandos Redis: JSON.SET y JSON.GET

### DIFF
--- a/docs/docker-3-redis.md
+++ b/docs/docker-3-redis.md
@@ -61,11 +61,15 @@ Por exemplo, se quixéramos persistir os datos no **RedisTimeSeries**, podemos e
 
  - **Autenticarse**: `AUTH contrasinal`
  - **Probar se estamos conectados**: `PING`
- - **Almacenar unha clave (KEY-VALUE)**: `set clave valor`
+ - **Almacenar unha clave (KEY-VALUE)**: `set clave valor` 
  - **Recuperar unha clave**: `get clave`
+ - **Almacenar datos JSON**: `JSON.SET clave_redis ruta_json($) valor_json`
+ - **Recuperar datos JSON**: `JSON.GET clave_redis ruta_json($)`
  - **Establecer ou mudar o contrasinal**: `config set requirepass 123quetal123`
  - **Crear un usuario**: `acl setuser ...`
  - **Pedir clave no CLI**: `config set requirepass 123quetal123`
+
+
 
 ## Uso con Python
 

--- a/docs/docker-3-redis.md
+++ b/docs/docker-3-redis.md
@@ -63,8 +63,8 @@ Por exemplo, se quixéramos persistir os datos no **RedisTimeSeries**, podemos e
  - **Probar se estamos conectados**: `PING`
  - **Almacenar unha clave (KEY-VALUE)**: `set clave valor` 
  - **Recuperar unha clave**: `get clave`
- - **Almacenar datos JSON**: `JSON.SET clave_documento ruta_json($) valor_json`
- - **Recuperar datos JSON**: `JSON.GET clave_documento ruta_json($)`
+ - **Almacenar datos JSON**: `JSON.SET clave $ valor_json`
+ - **Recuperar datos JSON**: `JSON.GET clave $`
  - **Establecer ou mudar o contrasinal**: `config set requirepass 123quetal123`
  - **Crear un usuario**: `acl setuser ...`
  - **Pedir clave no CLI**: `config set requirepass 123quetal123`

--- a/docs/docker-3-redis.md
+++ b/docs/docker-3-redis.md
@@ -63,13 +63,11 @@ Por exemplo, se quixéramos persistir os datos no **RedisTimeSeries**, podemos e
  - **Probar se estamos conectados**: `PING`
  - **Almacenar unha clave (KEY-VALUE)**: `set clave valor` 
  - **Recuperar unha clave**: `get clave`
- - **Almacenar datos JSON**: `JSON.SET clave_redis ruta_json($) valor_json`
- - **Recuperar datos JSON**: `JSON.GET clave_redis ruta_json($)`
+ - **Almacenar datos JSON**: `JSON.SET clave_documento ruta_json($) valor_json`
+ - **Recuperar datos JSON**: `JSON.GET clave_documento ruta_json($)`
  - **Establecer ou mudar o contrasinal**: `config set requirepass 123quetal123`
  - **Crear un usuario**: `acl setuser ...`
  - **Pedir clave no CLI**: `config set requirepass 123quetal123`
-
-
 
 ## Uso con Python
 


### PR DESCRIPTION
**Descripción**: 
Este PR añade documentación necesario sobre el uso de los comandos Redis JSON en entorno CLI.

**Cambios Realizados**:
Añadido el formato de los comandos Redis JSON (JSON.SET y JSON.GET)


**Por qué son necesarios estos cambios**:
La documentación anterior no estaba actualizada con los comandos JSON, lo que puede dar a pie confusión a la hora de introducir o leer un JSON. 
